### PR TITLE
[WIP] Move checksum to pod template

### DIFF
--- a/model-builder/templates/configmap.yaml
+++ b/model-builder/templates/configmap.yaml
@@ -4,7 +4,5 @@ metadata:
   name: {{ include "model-builder.fullname" . }}
   labels:
     {{- include "model-builder.labels" . | nindent 4 }}
-  annotations:
-    checksum/config: {{ include "config-map-contents" . | sha256sum }}
 data:
   {{ include "config-map-contents" . }}

--- a/model-builder/templates/deployment.yaml
+++ b/model-builder/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         {{- include "model-builder.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include "config-map-contents" . | sha256sum }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Checksum needs to be defined in the deployment's pod
template annotations as that what is what is getting deployed
upon a configmap change. Configmap changes alone won't trigger
a re-deployment unless the checksum is defined there.

TODO: Add README