### PR TITLE
Make serviceMonitor default metric collection behavior

### DIFF
--- a/charts/asserts/Chart.yaml
+++ b/charts/asserts/Chart.yaml
@@ -4,7 +4,7 @@ description: Asserts Helm Chart to configure entire asserts stack
 icon: https://www.asserts.ai/favicon.png
 type: application
 
-version: 1.4.0
+version: 1.5.0
 
 dependencies:
   ## asserts charts ##

--- a/charts/asserts/templates/config/tsdb-scrape-configmap.yaml
+++ b/charts/asserts/templates/config/tsdb-scrape-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tsdb.server.scrape.enabled }}
+{{- if .Values.tsdb.server.scrape.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,6 +10,114 @@ data:
       scrape_interval: {{.Values.grafana.scrapeInterval}}
 
     scrape_configs:
+    ### asserts-alerts: always scraped by the Asserts VM Instance ###
+    - job_name: asserts-alerts
+      kubernetes_sd_configs:
+      - namespaces:
+          names:
+          - {{ .Release.Namespace }}
+        role: endpoints
+      honor_labels: true
+      honor_timestamps: true
+      metric_relabel_configs:
+      - action: replace
+        regex: asserts-alerts
+        replacement: ""
+        source_labels:
+        - job
+        target_label: job
+      - action: replace
+        regex: dummy
+        replacement: ""
+        source_labels:
+        - instance
+        target_label: instance
+      - action: keep
+        regex: .+
+        source_labels:
+        - tenant
+      metrics_path: /api-server/assertion-metrics
+      relabel_configs:
+      - action: keep
+        regex: asserts
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_service_label_app_kubernetes_io_name
+      - action: keep
+        regex: {{ .Release.Name }}
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_service_label_app_kubernetes_io_instance
+      - action: keep
+        regex: server
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_service_label_app_kubernetes_io_component
+      - action: keep
+        regex: http
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_endpoint_port_name
+      - action: replace
+        regex: (.+)
+        replacement: $1
+        separator: ;
+        source_labels:
+        - job
+        target_label: source_job
+      - action: replace
+        regex: (.+)
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __address__
+        target_label: source_instance
+      - action: replace
+        regex: Node;(.*)
+        replacement: ${1}
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_endpoint_address_target_kind
+        - __meta_kubernetes_endpoint_address_target_name
+        target_label: source_node
+      - action: replace
+        regex: Pod;(.*)
+        replacement: ${1}
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_endpoint_address_target_kind
+        - __meta_kubernetes_endpoint_address_target_name
+        target_label: source_pod
+      - action: replace
+        regex: (.*)
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: source_namespace
+      - action: replace
+        regex: (.*)
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: source_service
+      - action: replace
+        regex: (.*)
+        replacement: $1
+        separator: ;
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: source_pod
+      scheme: http
+      scrape_interval: 30s
+      scrape_timeout: 15s
+
+    {{- if or (not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) (not (.Values.serviceMonitor.enabled)) }}
     ### asserts services ###
     - job_name: {{ .Release.Name }}-server
       kubernetes_sd_configs:
@@ -862,110 +970,5 @@ data:
         replacement: {{ .Values.assertsClusterSite }}
         action: replace
       {{- end }}
-
-    - job_name: asserts-alerts
-      kubernetes_sd_configs:
-      - namespaces:
-          names:
-          - {{ .Release.Namespace }}
-        role: endpoints
-      honor_labels: true
-      honor_timestamps: true
-      metric_relabel_configs:
-      - action: replace
-        regex: asserts-alerts
-        replacement: ""
-        source_labels:
-        - job
-        target_label: job
-      - action: replace
-        regex: dummy
-        replacement: ""
-        source_labels:
-        - instance
-        target_label: instance
-      - action: keep
-        regex: .+
-        source_labels:
-        - tenant
-      metrics_path: /api-server/assertion-metrics
-      relabel_configs:
-      - action: keep
-        regex: asserts
-        replacement: $1
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_service_label_app_kubernetes_io_name
-      - action: keep
-        regex: {{ .Release.Name }}
-        replacement: $1
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_service_label_app_kubernetes_io_instance
-      - action: keep
-        regex: server
-        replacement: $1
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_service_label_app_kubernetes_io_component
-      - action: keep
-        regex: http
-        replacement: $1
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_endpoint_port_name
-      - action: replace
-        regex: (.+)
-        replacement: $1
-        separator: ;
-        source_labels:
-        - job
-        target_label: source_job
-      - action: replace
-        regex: (.+)
-        replacement: $1
-        separator: ;
-        source_labels:
-        - __address__
-        target_label: source_instance
-      - action: replace
-        regex: Node;(.*)
-        replacement: ${1}
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_endpoint_address_target_kind
-        - __meta_kubernetes_endpoint_address_target_name
-        target_label: source_node
-      - action: replace
-        regex: Pod;(.*)
-        replacement: ${1}
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_endpoint_address_target_kind
-        - __meta_kubernetes_endpoint_address_target_name
-        target_label: source_pod
-      - action: replace
-        regex: (.*)
-        replacement: $1
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_namespace
-        target_label: source_namespace
-      - action: replace
-        regex: (.*)
-        replacement: $1
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_service_name
-        target_label: source_service
-      - action: replace
-        regex: (.*)
-        replacement: $1
-        separator: ;
-        source_labels:
-        - __meta_kubernetes_pod_name
-        target_label: source_pod
-      scheme: http
-      scrape_interval: 30s
-      scrape_timeout: 15s
+      {{- end }}
 {{- end }}

--- a/charts/asserts/templates/servicemonitor.yaml
+++ b/charts/asserts/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (.Values.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name:  {{ include "asserts.name" . }}
+  labels: {{- include "asserts.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 -}}
+    {{- end }}
+spec:
+  endpoints:
+  {{- range $endpoint := .Values.serviceMonitor.endpoints }}
+    - port: {{ $endpoint.port }}
+  {{- with $endpoint.path }}
+      path: {{ . }}
+  {{- end }}
+  {{- with $endpoint.honorLabels }}
+      honorLabels: {{ . }}
+  {{- end }}
+  {{- with $endpoint.interval }}
+      interval: {{ . }}
+  {{- end }}
+  {{- with $endpoint.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+  {{- end }}
+  {{- with $endpoint.relabelings }}
+      relabelings: {{ include "common.tplvalues.render" ( dict "value" $endpoint.relabelings "context" $) | nindent 8 }}
+  {{- end }}
+  {{- with $endpoint.metricRelabelings }}
+      metricRelabelings: {{ include "common.tplvalues.render" ( dict "value" $endpoint.metricRelabelings "context" $) | nindent 8 }}
+  {{- end }}
+  {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -25,10 +25,50 @@ serviceAccount:
   annotations: {}
   extraLabels: {}
 
+## If Prometheus-Operator is used (detected by checking "monitoring.coreos.com/v1" api existence)
+## Then they will be created, else the Asserts Tsdb will scrape the services
+##
+serviceMonitor:
+  enabled: true
+  # endpoints and appropriate relabelings
+  # relabelings used to avoid duplicates
+  # this allows us to avoid errors and keep everything in one
+  # ServiceMonitor
+  endpoints:
+    - port: http
+      path: /api-server/actuator/prometheus
+      relabelings:
+        - sourceLabels: [job]
+          regex: "{{.Release.Name}}-server"
+          action: keep
+    - port: http
+      path: /metrics
+      relabelings:
+        - sourceLabels: [job]
+          regex: "{{.Release.Name}}-server"
+          action: drop
+        - sourceLabels: [job]
+          regex: "{{.Release.Name}}-ui"
+          action: drop
+        - sourceLabels: [job]
+          regex: "{{.Release.Name}}-alertmanager-headless"
+          action: drop
+    - port: http-metrics
+      path: /metrics
+  # Use if you need to add a label that matches
+  # your prometheus-operator serviceMonitorSelector (e.g. release: kube-prometheus-stack)
+  extraLabels: {}
+
 ## Asserts cluster env and site
-## This should be set to the env and site
+##
+## IGNORE IF RUNNING Promtheus-Operator!!!
+##
+## This is required in order for Asserts to scrape a
+## and monitor itself. This should be set to the env and site
 ## of the cluster asserts is being installed in.
-#
+## This means that the env and site of the datasource
+## for this cluster (set in the Asserts UI), should
+## match these values.
 assertsClusterEnv: ""
 assertsClusterSite: ""
 
@@ -752,5 +792,6 @@ postgres:
     enabled: true
     service:
       annotations:
-        # set to false since the Asserts TSDB is already scraping this endpoint
+        # set to false since this chart is handling scraping for this service
+        # the Asserts ServiceMonitor is used or the Asserts TSDB is already scraping this endpoint
         prometheus.io/scrape: "false"


### PR DESCRIPTION
This change will automatically install a serviceMonitor for Asserts services that an existing Prometheus Operator in the cluster can pickup. This will allow us to ignore the `assertsClusterEnv` and `assertsClusterSite` values when Prom-Operator is present. Asserts-Alerts are still scraped by the tsdb config as we always want to control that, else assertions will not work.

If the cluster Asserts is being installed in does not have Prometheus-Operator, then we will install the chart as we always have been and `assertsClusterEnv/Site` will need to match up with the env and site of the datasource of the Prometheus where Asserts is installed.