### PR TITLE
make scrap configurable and version as our own chart

### DIFF
--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.69.0
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.8.12
+version: 1.0.0
 maintainers:
 - name: Asserts
   url: https://github.com/asserts


### PR DESCRIPTION
Make the scrape path configureable (needed for autoreloading/custom mounting). Also version to 1.0.0 since we are using this chart and it's diverging from the original.