### PR TITLE
Add tsdb scrape config reloader and update README

### DIFF
--- a/charts/asserts/Chart.lock
+++ b/charts/asserts/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.0
 - name: victoria-metrics-single
   repository: https://asserts.github.io/helm-charts
-  version: 0.8.12
+  version: 1.0.0
 - name: alertmanager
   repository: https://asserts.github.io/helm-charts
   version: 0.14.0
@@ -26,5 +26,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.23
-digest: sha256:2289f73767e29eb3d50a7a224b5f4ddcda340feb2c0a0938d4c5e7a711ed8bfb
-generated: "2022-09-16T13:52:47.368838-07:00"
+digest: sha256:b3c1b799a418364aaa1fcea3c839945d761bc848e310047dc440765f9dc51d23
+generated: "2022-10-20T14:24:17.474167-07:00"

--- a/charts/asserts/Chart.yaml
+++ b/charts/asserts/Chart.yaml
@@ -4,7 +4,7 @@ description: Asserts Helm Chart to configure entire asserts stack
 icon: https://www.asserts.ai/favicon.png
 type: application
 
-version: 1.6.0
+version: 1.7.0
 
 dependencies:
   ## asserts charts ##
@@ -15,7 +15,7 @@ dependencies:
     condition: knowledge-sensor.enabled
   - name: victoria-metrics-single
     repository: https://asserts.github.io/helm-charts
-    version: 0.8.12
+    version: 1.0.0
     alias: tsdb
     condition: tsdb.enabled
   - name: alertmanager

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -27,8 +27,6 @@ helm install asserts asserts/asserts
 
 ### You ARE NOT running Prometheus-Operator in the same cluster as where Asserts is installed
 
-To install the chart with the release name `asserts`:
-
 Create a values file, here we will call it `your-values.yaml`:
 
 ```yaml

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -17,14 +17,30 @@ This chart bootstraps an [Asserts](https://www.asserts.ai) deployment on a [Kube
 
 ## Installing the Chart
 
-To install the chart with the release name `asserts` and Prometheus endpoint behind the service `kube-prometheus-stack-prometheus` in the `default` namespace:
+### You ARE running Prometheus-Operator in the same cluster you are installing Asserts
+
+```bash
+helm repo add asserts https://asserts.github.io/helm-charts
+helm repo update
+helm install asserts asserts/asserts
+```
+
+### You ARE NOT running Prometheus-Operator in the same cluster as where Asserts is installed
+
+To install the chart with the release name `asserts`:
 
 Create a values file, here we will call it `your-values.yaml`:
 
 ```yaml
 ## Asserts cluster env and site
-## This should be set to the env and site
+##
+## IGNORE IF RUNNING Promtheus-Operator!!!
+##
+## This is required in order for Asserts to scrape a
+## and monitor itself. This should be set to the env and site
 ## of the cluster asserts is being installed in.
+## This means that the env and site of the datasource
+## for this cluster (set in the Asserts UI after installing)
 assertsClusterEnv: your-env
 # optional (e.g. us-west-2)
 assertsClusterSite: ""
@@ -35,6 +51,8 @@ helm repo add asserts https://asserts.github.io/helm-charts
 helm repo update
 helm install asserts asserts/asserts -f your-values.yaml
 ```
+
+## Verify and Access
 
 Once all containers are initialized and running:
 
@@ -47,7 +65,6 @@ You can then login to the asserts-ui by running:
 ```bash
 kubectl port-forward svc/asserts-ui 8080
 ```
-
 
 And opening your browser to [http://localhost:8080](http://localhost:8080)
 you will be directed to the Asserts Registration page. There you can acquire

--- a/charts/asserts/templates/config/tsdb-scrape-configmap.yaml
+++ b/charts/asserts/templates/config/tsdb-scrape-configmap.yaml
@@ -4,6 +4,11 @@ kind: ConfigMap
 metadata:
   name: asserts-tsdb-scrapeconfig
   labels: {{- include "asserts.labels" . | nindent 4 }}
+    {{- with .Values.tsdb.server.scrape.extraLabels }}
+    {{- toYaml . | nindent 4 -}}
+    {{- end }}
+  annotations:
+    k8s-sidecar-target-directory: {{ .Values.tsdb.server.scrape.configDir }}
 data:
   scrape.yml: |
     global:

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -514,6 +514,22 @@ tsdb:
         volumeMounts:
           - name: relabel-config
             mountPath: /opt/asserts/relabel
+      ## initially add scrape config to volume on startup
+      ## This is a way to make sure the tsdb doesn't startup with
+      ## an empty scrape config as it will crash in that scenario
+      - name: init-add-scrape-config
+        image: asserts/k8s-sidecar:1.14.2
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: LABEL
+            value: bootstrap-scrape-config
+          - name: FOLDER
+            value: /opt/asserts/scrape
+          - name: METHOD
+            value: LIST
+        volumeMounts:
+          - name: scrape-config
+            mountPath: /opt/asserts/scrape
 
     extraArgs:
       loggerFormat: default
@@ -527,7 +543,11 @@ tsdb:
     ## scrape configuration for the tsdb in config/tsdb-scrape-configmap.yaml
     scrape:
       enabled: true
+      configDir: /opt/asserts/scrape
+      configPath: /opt/asserts/scrape/scrape.yml
       configMap: asserts-tsdb-scrapeconfig
+      extraLabels:
+        bootstrap-scrape-config: "1"
 
     persistentVolume:
       size: 8Gi
@@ -535,11 +555,7 @@ tsdb:
     resources: {}
 
     extraContainers:
-      ## TODO: config-sidecar takes care of hot loading relabeling rules
-      ##       at the moment, the scrapeconfig is not currently hot loaded.
-      ##       The scrapeconfig shouldn't need to be overridden in the values
-      ##       file but can be reloaded by triggering the the REQ_URL below
-      - name: config-sidecar
+      - name: relabel-config-sidecar
         image: asserts/k8s-sidecar:1.14.2
         imagePullPolicy: IfNotPresent
         env:
@@ -552,13 +568,30 @@ tsdb:
         volumeMounts:
           - name: relabel-config
             mountPath: /opt/asserts/relabel
+      - name: scrape-config-sidecar
+        image: asserts/k8s-sidecar:1.14.2
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: LABEL
+            value: bootstrap-scrape-config
+          - name: FOLDER
+            value: /opt/asserts/scrape
+          - name: REQ_URL
+            value: http://localhost:8428/-/reload
+        volumeMounts:
+          - name: scrape-config
+            mountPath: /opt/asserts/scrape
 
     extraVolumeMounts:
       - name: relabel-config
         mountPath: /opt/asserts/relabel
+      - name: scrape-config
+        mountPath: /opt/asserts/scrape
 
     extraVolumes:
       - name: relabel-config
+        emptyDir: {}
+      - name: scrape-config
         emptyDir: {}
 
 


### PR DESCRIPTION
This will autoload the tsdbscrape config when it's updated. It rarely is updated, but should be monitored for when we make scrape config changes AND the statefulset doesn't change.