### PR TITLE
Upgrade sidecars to use newer kiwigrid version

### DIFF
--- a/charts/asserts/Chart.yaml
+++ b/charts/asserts/Chart.yaml
@@ -4,7 +4,7 @@ description: Asserts Helm Chart to configure entire asserts stack
 icon: https://www.asserts.ai/favicon.png
 type: application
 
-version: 1.11.0
+version: 1.12.0
 
 dependencies:
   ## asserts charts ##

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -506,7 +506,7 @@ tsdb:
       ## empty rules as it will crash or run with an empty
       ## set.
       - name: init-add-rule-files
-        image: asserts/k8s-sidecar:1.14.2
+        image: kiwigrid/k8s-sidecar:1.21.0
         imagePullPolicy: IfNotPresent
         env:
           - name: LABEL
@@ -522,7 +522,7 @@ tsdb:
       ## This is a way to make sure the tsdb doesn't startup with
       ## an empty scrape config as it will crash in that scenario
       - name: init-add-scrape-config
-        image: asserts/k8s-sidecar:1.14.2
+        image: kiwigrid/k8s-sidecar:1.21.0
         imagePullPolicy: IfNotPresent
         env:
           - name: LABEL
@@ -560,7 +560,7 @@ tsdb:
 
     extraContainers:
       - name: relabel-config-sidecar
-        image: asserts/k8s-sidecar:1.14.2
+        image: kiwigrid/k8s-sidecar:1.21.0
         imagePullPolicy: IfNotPresent
         env:
           - name: LABEL
@@ -573,7 +573,7 @@ tsdb:
           - name: relabel-config
             mountPath: /opt/asserts/relabel
       - name: scrape-config-sidecar
-        image: asserts/k8s-sidecar:1.14.2
+        image: kiwigrid/k8s-sidecar:1.21.0
         imagePullPolicy: IfNotPresent
         env:
           - name: LABEL
@@ -719,7 +719,7 @@ promxyruler:
 
   extraContainers:
     - name: rules-config-sidecar
-      image: asserts/k8s-sidecar:1.14.2
+      image: kiwigrid/k8s-sidecar:1.21.0
       imagePullPolicy: IfNotPresent
       env:
         - name: LABEL


### PR DESCRIPTION
Will bump your PR to 1.13 @jgehrett. Tested this throroughly in chief/self and locally with many rule updates, notification additions, promxy updates, etc..