### PR TITLE
Add global storageClass support for asserts

### DIFF
--- a/charts/asserts/Chart.lock
+++ b/charts/asserts/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 1.0.0
 - name: victoria-metrics-single
   repository: https://asserts.github.io/helm-charts
-  version: 1.0.0
+  version: 1.1.0
 - name: alertmanager
   repository: https://asserts.github.io/helm-charts
-  version: 0.14.0
+  version: 1.0.0
 - name: promxy
   repository: https://asserts.github.io/helm-charts
   version: 0.7.0
@@ -26,5 +26,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.23
-digest: sha256:b3c1b799a418364aaa1fcea3c839945d761bc848e310047dc440765f9dc51d23
-generated: "2022-10-20T14:24:17.474167-07:00"
+digest: sha256:c0b26e2dde9c10c982c2fab8a851100d6e8ad0cf7c2a6bdf63583023644bf92f
+generated: "2022-11-29T09:21:48.692341-08:00"

--- a/charts/asserts/Chart.yaml
+++ b/charts/asserts/Chart.yaml
@@ -4,7 +4,7 @@ description: Asserts Helm Chart to configure entire asserts stack
 icon: https://www.asserts.ai/favicon.png
 type: application
 
-version: 1.13.0
+version: 1.14.0
 
 dependencies:
   ## asserts charts ##
@@ -15,12 +15,12 @@ dependencies:
     condition: knowledge-sensor.enabled
   - name: victoria-metrics-single
     repository: https://asserts.github.io/helm-charts
-    version: 1.0.0
+    version: 1.1.0
     alias: tsdb
     condition: tsdb.enabled
   - name: alertmanager
     repository: https://asserts.github.io/helm-charts
-    version: 0.14.0
+    version: 1.0.0
     condition: alertmanager.enabled
   - name: promxy
     repository: https://asserts.github.io/helm-charts

--- a/charts/asserts/templates/_helpers.tpl
+++ b/charts/asserts/templates/_helpers.tpl
@@ -58,23 +58,6 @@ asserts
 {{- end }}
 
 {{/*
-Return  the proper Storage Class
-{{ include "asserts.storageClass"  . }}
-*/}}
-{{- define "asserts.storageClass" -}}
-
-{{- $storageClass := .Values.server.persistence.storageClass -}}
-{{- if $storageClass -}}
-  {{- if (eq "-" $storageClass) -}}
-      {{- printf "storageClassName: \"\"" -}}
-  {{- else }}
-      {{- printf "storageClassName: %s" $storageClass -}}
-  {{- end -}}
-{{- end -}}
-
-{{- end -}}
-
-{{/*
 The asserts tenant name
 {{ include "asserts.tenant"  . }}
 */}}

--- a/charts/asserts/templates/grafana/statefulset.yaml
+++ b/charts/asserts/templates/grafana/statefulset.yaml
@@ -131,5 +131,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.grafana.persistence.size | quote }}
-        {{ include "asserts.storageClass"  . }}
+        {{ include "common.storage.class" (dict "persistence" .Values.grafana.persistence "global" .Values.global) }}
   {{- end }}

--- a/charts/asserts/templates/server/statefulset.yaml
+++ b/charts/asserts/templates/server/statefulset.yaml
@@ -114,5 +114,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.server.persistence.size | quote }}
-        {{ include "asserts.storageClass"  . }}
+        {{ include "common.storage.class" (dict "persistence" .Values.server.persistence "global" .Values.global) }}
   {{- end }}

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -1,3 +1,12 @@
+## Global parameters
+##
+## This will override any available parameters in this chart
+## as well as dependent charts
+##
+## Current available global parameters: storageClass
+global:
+  storageClass: ""
+
 nameOverride: ""
 fullnameOverride: ""
 clusterDomain: svc.cluster.local


### PR DESCRIPTION
Removed previous asserts storage class definition. Since this chart has the common bitnami chart as a dependency, we can just use that  template for asserts-server and grafana. Tested against and existing installation, checked with a new global values set, and a new installation as well.