### PR TITLE
Aramos/sc 14225

### DIFF
--- a/charts/asserts/Chart.lock
+++ b/charts/asserts/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: knowledge-sensor
   repository: https://asserts.github.io/helm-charts
-  version: 1.0.0
+  version: 1.1.0
 - name: victoria-metrics-single
   repository: https://asserts.github.io/helm-charts
   version: 1.1.0
@@ -26,5 +26,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.23
-digest: sha256:c0b26e2dde9c10c982c2fab8a851100d6e8ad0cf7c2a6bdf63583023644bf92f
-generated: "2022-11-29T09:21:48.692341-08:00"
+digest: sha256:8eea76e7c56330e8a61698f100608b1a37dc3493c264fb23e115c4e551e69bd9
+generated: "2022-12-09T09:23:24.971235-08:00"

--- a/charts/asserts/Chart.yaml
+++ b/charts/asserts/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   # local charts in asserts/charts
   - name: knowledge-sensor
     repository: https://asserts.github.io/helm-charts
-    version: 1.0.0
+    version: 1.1.0
     condition: knowledge-sensor.enabled
   - name: victoria-metrics-single
     repository: https://asserts.github.io/helm-charts

--- a/charts/asserts/Chart.yaml
+++ b/charts/asserts/Chart.yaml
@@ -4,7 +4,7 @@ description: Asserts Helm Chart to configure entire asserts stack
 icon: https://www.asserts.ai/favicon.png
 type: application
 
-version: 1.17.0
+version: 1.18.0
 
 dependencies:
   ### asserts charts ###

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -22,7 +22,7 @@ This chart bootstraps an [Asserts](https://www.asserts.ai) deployment on a [Kube
 ```bash
 helm repo add asserts https://asserts.github.io/helm-charts
 helm repo update
-helm install asserts asserts/asserts -n asserts --create-namespace
+helm upgrade --install asserts asserts/asserts -n asserts --create-namespace
 ```
 
 ### You ARE NOT running Prometheus-Operator in the same cluster as where Asserts is installed
@@ -51,7 +51,7 @@ serviceMonitor:
 ```bash
 helm repo add asserts https://asserts.github.io/helm-charts
 helm repo update
-helm install asserts asserts/asserts -n asserts -f values.yaml --create-namespace
+helm upgrade --install asserts asserts/asserts -n asserts -f values.yaml --create-namespace
 ```
 
 ## Verify and Access

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -54,6 +54,9 @@ helm repo update
 helm upgrade --install asserts asserts/asserts -n asserts -f values.yaml --create-namespace
 ```
 
+When Asserts is spinning up for the first time, it usually takes about 3-4 minutes
+but could take longer depending on the hardware resources allocated (e.g. a kind cluster).
+
 ## Verify and Access
 
 Once all containers are initialized and running:

--- a/charts/asserts/templates/_helpers.tpl
+++ b/charts/asserts/templates/_helpers.tpl
@@ -66,6 +66,28 @@ bootstrap
 {{- end }}
 
 {{/*
+redisgraph service endpoint depending if in standalone or sentinel mode
+*/}}
+{{- define "asserts.redisgraphServiceEndpoint" -}}
+{{- if .Values.redisgraph.sentinel.enabled -}}
+{{ .Values.redisgraph.fullnameOverride }}.{{ include "domain"  . }}:26379
+{{- else -}}
+{{.Values.redisgraph.fullnameOverride}}-master.{{ include "domain"  . }}:6379
+{{- end }}
+{{- end }}
+
+{{/*
+redisearch service endpoint depending if in standalone or sentinel mode
+*/}}
+{{- define "asserts.redisearchServiceEndpoint" -}}
+{{- if .Values.redisearch.sentinel.enabled -}}
+{{.Values.redisearch.fullnameOverride}}.{{ include "domain"  . }}:26379
+{{- else -}}
+{{.Values.redisearch.fullnameOverride}}-master.{{ include "domain"  . }}:6379
+{{- end }}
+{{- end }}
+
+{{/*
 Get KubeVersion removing pre-release information.
 */}}
 {{- define "kubeVersion" -}}

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -140,7 +140,7 @@ server:
     repository: asserts/asserts-server
     pullPolicy: IfNotPresent
     ## Overrides the image tag whose default is the chart appVersion.
-    tag: v0.2.415
+    tag: v0.2.432
 
   initContainers:
     - name: wait-for-postgres
@@ -148,6 +148,20 @@ server:
       imagePullPolicy: IfNotPresent
       args:
         - "{{.Values.postgres.fullnameOverride}}.{{.Release.Namespace}}.{{.Values.clusterDomain}}:5432"
+        - "-t"
+        - "420"
+    - name: wait-for-redisgraph
+      image: asserts/wait-for:v2.2.3
+      imagePullPolicy: IfNotPresent
+      args:
+        - "{{include \"asserts.redisgraphServiceEndpoint\" .}}"
+        - "-t"
+        - "420"
+    - name: wait-for-redisearch
+      image: asserts/wait-for:v2.2.3
+      imagePullPolicy: IfNotPresent
+      args:
+        - "{{include \"asserts.redisearchServiceEndpoint\" .}}"
         - "-t"
         - "420"
 
@@ -286,7 +300,7 @@ ui:
     repository: asserts/asserts-ui
     pullPolicy: IfNotPresent
     ## Overrides the image tag whose default is the chart appVersion.
-    tag: v0.1.1093
+    tag: v0.1.1101
 
   imagePullSecrets: []
 
@@ -374,7 +388,7 @@ grafana:
     repository: asserts/grafana
     pullPolicy: IfNotPresent
     ## Overrides the image tag whose default is the chart appVersion.
-    tag: v1.0.180
+    tag: v1.0.188
 
   imagePullSecrets: []
 
@@ -683,7 +697,7 @@ redisgraph:
   ## ref: https://hub.docker.com/repository/docker/asserts/redismod
   image:
     repository: asserts/redismod
-    tag: 6.26
+    tag: 6.2.7-rg-v2.8.20-rs-v2.14.6
 
   nameOverride: asserts-redisgraph
   fullnameOverride: asserts-redisgraph

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -525,7 +525,7 @@ grafana:
 knowledge-sensor:
   image:
     repository: asserts/knowledge-sensor
-    tag: v1.1.9
+    tag: v1.1.11
 
   serviceAccount:
     create: false


### PR DESCRIPTION
Upgrade self-hosted release. Here we upgrade redisgraph/search, update the knowledge-sensor dependency, and add an init process to ensure redis upgrades before the asserts-server.