### PR TITLE
Rework for promscrape options

### DIFF
--- a/charts/asserts/Chart.yaml
+++ b/charts/asserts/Chart.yaml
@@ -4,7 +4,7 @@ description: Asserts Helm Chart to configure entire asserts stack
 icon: https://www.asserts.ai/favicon.png
 type: application
 
-version: 1.20.0
+version: 1.21.0
 
 dependencies:
   ### asserts charts ###

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -10,17 +10,12 @@ This chart bootstraps an [Asserts](https://www.asserts.ai) deployment on a [Kube
 
 - Kubernetes 1.17+
 - Helm 3.2.0+
-- PV provisioner support in the underlying infrastructure
+- PV provisioner support for the underlying infrastructure
 - A Prometheus compatible endpoint to query
 - [kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) (metrics from the Prometheus endpoint)
 - [node-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter) (metrics from the Prometheus endpoint)
 
 ## Installing the Chart
-
-Please have a look at the 3 options below and decide which one matches your use case
-before proceeding with one of them.
-
-### You ARE running Prometheus-Operator in the same cluster you are installing Asserts
 
 ```bash
 helm repo add asserts https://asserts.github.io/helm-charts
@@ -28,69 +23,8 @@ helm repo update
 helm upgrade --install asserts asserts/asserts -n asserts --create-namespace
 ```
 
-> **Note:** In order for your Prometheus-Operator's Prometheus to pickup the Asserts ServiceMonitor
-you need to ensure that the `serviceMonitorSelector` for your Prometheus is added to the Asserts
-ServiceMonitor's extraLabels. Use the following steps to verify the Asserts ServiceMonitor will be
-picked up by your Prometheus.
-
-Check your Prometheus's `serviceMonitorSelector`:
-
-```
-kubectl get prometheus -n <namespace-of-your-prometheus> -ojsonpath='{.items[].spec.serviceMonitorSelector}'
-```
-
-Ex Output:
-
-```
-{"matchLabels":{"release":"kube-prometheus-stack"}}
-```
-
-This requires you to add the following to a values file:
-
-```
-serviceMonitor:
-  extraLabels:
-    release: kube-prometheus-stack
-```
-
-### You ARE running VANILLA Prometheus in the same cluster Asserts is being installed
-
-This assumes you are using annotation based [kubernetes service discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) in your Prometheus configuration such as used in the official [Prometheus Helm Chart default scrape config](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml#L771). This means that the annotation `prometheus.io/scrape: "true"` will let your Prometheus know to scrape Asserts services.
-
-Create a values file with the following, here we will call it `values.yaml`:
-
-```yaml
-# Set since not running Prometheus-Operator (default is true)
-serviceMonitor:
-  enabled: false
-```
-
-```bash
-helm repo add asserts https://asserts.github.io/helm-charts
-helm repo update
-helm upgrade --install asserts asserts/asserts -n asserts -f values.yaml --create-namespace
-```
-
-### You ARE NOT running Prometheus/Prometheus-Operator in the same cluster where Asserts is being installed (test or management cluster).
-
-Create a values file with the following, here we will call it `values.yaml`:
-
-```yaml
-## When this is set to true, the Asserts Tsdb will scrape
-## all of the Asserts Services.
-selfScrape: true
-
-## Set since not running Prometheus-Operator (default is true)
-serviceMonitor:
-  enabled: false
-```
-
-```bash
-helm repo add asserts https://asserts.github.io/helm-charts
-helm repo update
-helm upgrade --install asserts asserts/asserts -n asserts -f values.yaml --create-namespace
-```
-
+There any many configuration options such as PagerDuty and Slack integrations. These can be configured with a values file.
+View all install configuration options [here](https://github.com/asserts/helm-charts/blob/master/charts/asserts/values.yaml).
 
 ## Verify and Access
 

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -43,7 +43,7 @@ You can then login to the asserts-ui by running:
 kubectl port-forward svc/asserts-ui 8080 -n asserts
 ```
 
-And opening your browser to http://localhost:8080, where you will be directed to the Asserts Registration page. There you can acquire a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/helm-chart#acquire-a-license)
+And opening your browser to [http://localhost:8080](http://localhost:8080), where you will be directed to the Asserts Registration page. There you can acquire a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/helm-chart#acquire-a-license)
 
 ## Configuring Promethueus DataSources
 

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -17,6 +17,9 @@ This chart bootstraps an [Asserts](https://www.asserts.ai) deployment on a [Kube
 
 ## Installing the Chart
 
+Please have a look at the 3 options below and decide which one matches your use case
+before proceeding with one of them.
+
 ### You ARE running Prometheus-Operator in the same cluster you are installing Asserts
 
 ```bash
@@ -25,24 +28,38 @@ helm repo update
 helm upgrade --install asserts asserts/asserts -n asserts --create-namespace
 ```
 
-### You ARE NOT running Prometheus-Operator in the same cluster as where Asserts is installed
+> **Note:** In order for your Prometheus-Operator's Prometheus to pickup the Asserts ServiceMonitor
+you need to ensure that the `serviceMonitorSelector` for your Prometheus is added to the Asserts
+ServiceMonitor's extraLabels. Use the following steps to verify the Asserts ServiceMonitor will be
+picked up by your Prometheus.
 
-Create a values file, here we will call it `values.yaml`:
+Check your Prometheus's `serviceMonitorSelector`:
+
+```
+kubectl get prometheus -n <namespace-of-your-prometheus> -ojsonpath='{.items[].spec.serviceMonitorSelector}'
+```
+
+Ex Output:
+
+```
+{"matchLabels":{"release":"kube-prometheus-stack"}}
+```
+
+This requires you to add the following to a values file:
+
+```
+serviceMonitor:
+  extraLabels:
+    release: kube-prometheus-stack
+```
+
+### You ARE running VANILLA Prometheus in the same cluster Asserts is being installed
+
+This assumes you are using annotation based [kubernetes service discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) in your Prometheus configuration such as used in the official [Prometheus Helm Chart default scrape config](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml#L771). This means that the annotation `prometheus.io/scrape: "true"` will let your Prometheus know to scrape Asserts services.
+
+Create a values file with the following, here we will call it `values.yaml`:
 
 ```yaml
-## Asserts cluster env and site
-##
-## IGNORE IF RUNNING Promtheus-Operator!!!
-##
-## This is required in order for Asserts to scrape a
-## and monitor itself. This should be set to the env and site
-## of the cluster asserts is being installed in.
-## This means that the env and site of the datasource
-## for this cluster (set in the Asserts UI after installing)
-assertsClusterEnv: <your-env>
-# optional (e.g. us-west-2)
-assertsClusterSite: ""
-
 # Set since not running Prometheus-Operator (default is true)
 serviceMonitor:
   enabled: false
@@ -54,10 +71,31 @@ helm repo update
 helm upgrade --install asserts asserts/asserts -n asserts -f values.yaml --create-namespace
 ```
 
-When Asserts is spinning up for the first time, it usually takes about 3-4 minutes
-but could take longer depending on the hardware resources allocated (e.g. a kind cluster).
+### You ARE NOT running Prometheus/Prometheus-Operator in the same cluster where Asserts is being installed (test or management cluster).
+
+Create a values file with the following, here we will call it `values.yaml`:
+
+```yaml
+## When this is set to true, the Asserts Tsdb will scrape
+## all of the Asserts Services.
+selfScrape: true
+
+## Set since not running Prometheus-Operator (default is true)
+serviceMonitor:
+  enabled: false
+```
+
+```bash
+helm repo add asserts https://asserts.github.io/helm-charts
+helm repo update
+helm upgrade --install asserts asserts/asserts -n asserts -f values.yaml --create-namespace
+```
+
 
 ## Verify and Access
+
+When Asserts is spinning up for the first time, it usually takes about 3-4 minutes
+but could take longer depending on the hardware resources allocated (e.g. a kind/k3d cluster).
 
 Once all containers are initialized and running:
 

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -45,7 +45,7 @@ kubectl port-forward svc/asserts-ui 8080 -n asserts
 
 And opening your browser to [http://localhost:8080](http://localhost:8080)
 you will be directed to the Asserts Registration page. There you can acquire
-a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/helm-chart#see-the-data)
+a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/helm-chart#acquire-a-license)
 
 ## Configuring Promethueus DataSources
 

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -52,6 +52,12 @@ a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/hel
 Configure your Prometheus DataSource which Asserts will connect to
 and query by following [these instructions](https://docs.asserts.ai/integrations/data-source/prometheus)
 
+## Upgrading Asserts
+
+```bash
+helm repo update
+helm upgrade --install asserts asserts/asserts -n asserts
+```
 ## Uninstalling the Chart
 
 To uninstall/delete the `asserts` deployment:

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -43,9 +43,7 @@ You can then login to the asserts-ui by running:
 kubectl port-forward svc/asserts-ui 8080 -n asserts
 ```
 
-And opening your browser to [http://localhost:8080](http://localhost:8080)
-you will be directed to the Asserts Registration page. There you can acquire
-a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/helm-chart#acquire-a-license)
+And opening your browser to http://localhost:8080, where you will be directed to the Asserts Registration page. There you can acquire a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/helm-chart#acquire-a-license)
 
 ## Configuring Promethueus DataSources
 

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -52,7 +52,7 @@ a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/hel
 Configure your Prometheus DataSource which Asserts will connect to
 and query by following [these instructions](https://docs.asserts.ai/integrations/data-source/prometheus)
 
-## Upgrading Asserts
+## Upgrading the Chart
 
 ```bash
 helm repo update

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -43,12 +43,15 @@ You can then login to the asserts-ui by running:
 kubectl port-forward svc/asserts-ui 8080 -n asserts
 ```
 
-And opening your browser to [http://localhost:8080](http://localhost:8080), where you will be directed to the Asserts Registration page. There you can acquire a license as seen [here](https://docs.asserts.ai/getting-started/self-hosted/helm-chart#acquire-a-license)
+And opening your browser to [http://localhost:8080](http://localhost:8080), where you will be directed to the Asserts Registration page. There you can acquire a license.
 
-## Configuring Promethueus DataSources
+## Acquire a License
 
-Configure your Prometheus DataSource which Asserts will connect to
-and query by following [these instructions](https://docs.asserts.ai/integrations/data-source/prometheus)
+Acquire a trial license by following [these steps](https://docs.asserts.ai/getting-started/self-hosted/helm-chart#acquire-a-license)
+
+## Configuring a Prometheus DataSource
+
+Configure your Prometheus DataSource which Asserts will connect to and query by following [these instructions](https://docs.asserts.ai/integrations/data-source/prometheus). Once you're connected, you can see the data and start observing!
 
 ## Upgrading the Chart
 

--- a/charts/asserts/README.md
+++ b/charts/asserts/README.md
@@ -11,9 +11,7 @@ This chart bootstraps an [Asserts](https://www.asserts.ai) deployment on a [Kube
 - Kubernetes 1.17+
 - Helm 3.2.0+
 - PV provisioner support for the underlying infrastructure
-- A Prometheus compatible endpoint to query
-- [kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) (metrics from the Prometheus endpoint)
-- [node-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter) (metrics from the Prometheus endpoint)
+- A Prometheus compatible endpoint with [kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) and [node-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter)
 
 ## Installing the Chart
 

--- a/charts/asserts/templates/_helpers.tpl
+++ b/charts/asserts/templates/_helpers.tpl
@@ -135,16 +135,3 @@ Return the domain to use
 {{- define "domain" -}}
 {{ .Release.Namespace }}.{{ .Values.clusterDomain }}
 {{- end -}}
-
-{{/*
-Add prometheus scrape annotation and set appropriately if prometheus-operator
-ServiceMonitor crd is not supported and Asserts is set to selfScrape.
-Values can be "true" or "false".
-*/}}
-{{- define "promScrapeAnnotation" -}}
-{{- if and (not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) (not (.Values.selfScrape)) }}
- {{- true -}}
-{{- else }}
- {{- false -}}
-{{- end -}}
-{{- end -}}

--- a/charts/asserts/templates/_helpers.tpl
+++ b/charts/asserts/templates/_helpers.tpl
@@ -135,3 +135,16 @@ Return the domain to use
 {{- define "domain" -}}
 {{ .Release.Namespace }}.{{ .Values.clusterDomain }}
 {{- end -}}
+
+{{/*
+Add prometheus scrape annotation and set appropriately if prometheus-operator
+ServiceMonitor crd is not supported and Asserts is set to selfScrape.
+Values can be "true" or "false".
+*/}}
+{{- define "promScrapeAnnotation" -}}
+{{- if and (not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) (not (.Values.selfScrape)) }}
+ {{- true -}}
+{{- else }}
+ {{- false -}}
+{{- end -}}
+{{- end -}}

--- a/charts/asserts/templates/authorization/service.yaml
+++ b/charts/asserts/templates/authorization/service.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- with .Values.authorization.extraLabels }}
     {{- toYaml . | nindent 4 -}}
     {{- end }}
-  {{- if .Values.authorization.service.annotations }}
-  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.authorization.service.annotations "context" $) | nindent 4 }}
+  {{- with .Values.authorization.service.annotations }}
+  annotations: {{ include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.authorization.service.type }}

--- a/charts/asserts/templates/authorization/service.yaml
+++ b/charts/asserts/templates/authorization/service.yaml
@@ -6,9 +6,8 @@ metadata:
     {{- with .Values.authorization.extraLabels }}
     {{- toYaml . | nindent 4 -}}
     {{- end }}
-  {{- if .Values.authorization.annotations }}
-  annotations:
-  {{- toYaml .Values.authorization.annotations | nindent 4 -}}
+  {{- if .Values.authorization.service.annotations }}
+  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.authorization.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.authorization.service.type }}

--- a/charts/asserts/templates/config/k8s-calls-rules-configmap.yaml
+++ b/charts/asserts/templates/config/k8s-calls-rules-configmap.yaml
@@ -21,7 +21,7 @@ data:
           # asserts-ui -> authorization
           - record: asserts:relation:calls
             expr: sum by (asserts_env, asserts_site, namespace)
-                    (asserts:request:rate5m{job="{{.Release}}-authorization", asserts_request_type="inbound"}}) > 0
+                    (asserts:request:rate5m{job="{{.Release.Name}}-authorization", asserts_request_type="inbound"}}) > 0
             labels:
               workload: {{.Release.Name}}-ui
               dst_workload: {{.Release.Name}}-authorization
@@ -135,7 +135,7 @@ data:
           # asserts-ui -> authorization
           - record: asserts:relation:calls
             expr: sum by (asserts_env, asserts_site, namespace)
-                    (asserts:request:rate5m{service="{{.Release}}-authorization", asserts_request_type="inbound"}}) > 0
+                    (asserts:request:rate5m{service="{{.Release.Name}}-authorization", asserts_request_type="inbound"}}) > 0
             labels:
               workload: {{.Release.Name}}-ui
               dst_workload: {{.Release.Name}}-authorization
@@ -239,4 +239,4 @@ data:
               workload: {{.Release.Name}}-grafana
               dst_workload: {{.Release.Name}}-promxyuser
               dst_namespace: {{.Release.Namespace}}
-{{- end }}
+ {{- end }}

--- a/charts/asserts/templates/config/k8s-calls-rules-configmap.yaml
+++ b/charts/asserts/templates/config/k8s-calls-rules-configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: asserts-k8s-calls-rules
   labels: {{- include "asserts.labels" . | nindent 4 }}
 data:
+  {{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (.Values.serviceMonitor.enabled) }}
   asserts-k8s-calls.yml: |
     groups:
       - name: asserts-k8s-calls.rules
@@ -15,6 +16,15 @@ data:
             labels:
               workload: {{.Release.Name}}-ui
               dst_workload: {{.Release.Name}}-server
+              dst_namespace: {{.Release.Namespace}}
+
+          # asserts-ui -> authorization
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{job="{{.Release}}-authorization", asserts_request_type="inbound"}}) > 0
+            labels:
+              workload: {{.Release.Name}}-ui
+              dst_workload: {{.Release.Name}}-authorization
               dst_namespace: {{.Release.Namespace}}
 
           # asserts-server -> postgres
@@ -108,3 +118,125 @@ data:
             labels:
               dst_job: {{.Release.Name}}-promxyuser
               dst_namespace: {{.Release.Namespace}}
+  {{- else }}
+  asserts-k8s-calls.yml: |
+    groups:
+      - name: asserts-k8s-calls.rules
+        rules:
+          # asserts-ui -> asserts-server
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{service="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context=~"/v1/.*"}) > 0
+            labels:
+              workload: {{.Release.Name}}-ui
+              dst_workload: {{.Release.Name}}-server
+              dst_namespace: {{.Release.Namespace}}
+
+          # asserts-ui -> authorization
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{service="{{.Release}}-authorization", asserts_request_type="inbound"}}) > 0
+            labels:
+              workload: {{.Release.Name}}-ui
+              dst_workload: {{.Release.Name}}-authorization
+              dst_namespace: {{.Release.Namespace}}
+
+          # asserts-server -> postgres
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{service="{{.Release.Name}}-postgres-metrics", namespace="{{.Release.Namespace}}", asserts_request_context="records_written"}) > 0
+            labels:
+              workload: {{.Release.Name}}-server
+              dst_workload: {{.Values.postgres.fullnameOverride}}
+              dst_namespace: {{.Release.Namespace}}
+
+          # asserts-server -> redisearch
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{service="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context=~".*Search.*"}) > 0
+            labels:
+              workload: {{.Release.Name}}-server
+              dst_workload: {{.Values.redisearch.fullnameOverride}}-metrics
+              dst_namespace: {{.Release.Namespace}}
+
+          # asserts-server -> redisgraph
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+              (asserts:request:rate5m{service="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context=~".*Graph.*"}) > 0
+            labels:
+              workload: {{.Release.Name}}-server
+              dst_workload: {{.Values.redisgraph.fullnameOverride}}-metrics
+              dst_namespace: {{.Release.Namespace}}
+
+          # asserts-server -> tsdb-server
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{service="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context=~"/api/v1/.*"}) > 0
+            labels:
+              workload: {{.Release.Name}}-server
+              dst_workload: {{.Release.Name}}-tsdb-server
+              dst_namespace: {{.Release.Namespace}}
+
+          # knowledge-sensor -> asserts-server
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{job="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context="/v4/prometheus/rules"}) > 0
+            labels:
+              workload: {{.Release.Name}}-knowledge-sensor
+              dst_workload: {{.Release.Name}}-server
+              dst_namespace: {{.Release.Namespace}}
+
+          # promxy -> tsdb-server
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{service="{{.Release.Name}}-tsdb-server", asserts_request_context="/api/v1/write"}) > 0
+            labels:
+              workload: {{.Release.Name}}-promxyruler
+              dst_workload: {{.Release.Name}}-tsdb-server
+              dst_namespace: {{.Release.Namespace}}
+
+          # promxy -> alertmanager
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace, container, job, asserts_request_type, asserts_request_context)
+                    (rate(asserts:request:total{service="asserts-promxyruler", alertmanager=~".*/api/v2/alerts"}[5m])) > 0
+            labels:
+              workload: {{.Release.Name}}-promxyruler
+              dst_workload: {{.Release.Name}}-alertmanager
+              dst_namespace: {{.Release.Namespace}}
+
+          # alertmanager -> asserts-server
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (asserts:request:rate5m{service="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context=~".*prometheus-alerts.*"}) > 0
+            labels:
+              workload: {{.Release.Name}}-alertmanager
+              dst_workload: {{.Release.Name}}-server
+              dst_namespace: {{.Release.Namespace}}
+
+          # asserts-server -> grafana
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (rate(http_server_requests_seconds_count{service="{{.Release.Name}}-server", uri="root"}[5m])) > 0
+            labels:
+              workload: {{.Release.Name}}-server
+              dst_workload: {{.Release.Name}}-grafana
+              dst_namespace: {{.Release.Namespace}}
+
+          # grafana -> tsdb-server
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace)
+                    (rate(grafana_datasource_request_total{service="{{.Release.Name}}-grafana"}[5m])) > 0
+            labels:
+              workload: {{.Release.Name}}-grafana
+              dst_workload: {{.Release.Name}}-tsdb-server
+              dst_namespace: {{.Release.Namespace}}
+
+          # grafana -> promxyuser
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace, job)
+                    (asserts:request:rate5m{service="{{.Release.Name}}-grafana", asserts_request_type="proxy"}) > 0
+            labels:
+              workload: {{.Release.Name}}-grafana
+              dst_workload: {{.Release.Name}}-promxyuser
+              dst_namespace: {{.Release.Namespace}}
+{{- end }}

--- a/charts/asserts/templates/config/k8s-calls-rules-configmap.yaml
+++ b/charts/asserts/templates/config/k8s-calls-rules-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: asserts-k8s-calls-rules
   labels: {{- include "asserts.labels" . | nindent 4 }}
 data:
-  {{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (.Values.serviceMonitor.enabled) }}
+  {{- if or (and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (.Values.serviceMonitor.enabled)) (.Values.selfScrape) }}
   asserts-k8s-calls.yml: |
     groups:
       - name: asserts-k8s-calls.rules
@@ -21,7 +21,7 @@ data:
           # asserts-ui -> authorization
           - record: asserts:relation:calls
             expr: sum by (asserts_env, asserts_site, namespace)
-                    (asserts:request:rate5m{job="{{.Release.Name}}-authorization", asserts_request_type="inbound"}}) > 0
+                    (asserts:request:rate5m{job="{{.Release.Name}}-authorization", asserts_request_type="inbound"}) > 0
             labels:
               workload: {{.Release.Name}}-ui
               dst_workload: {{.Release.Name}}-authorization
@@ -111,14 +111,72 @@ data:
               dst_job: {{.Release.Name}}-tsdb-server
               dst_namespace: {{.Release.Namespace}}
 
+          # asserts-server -> grafana
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace, job)
+                    (asserts:request:rate5m{job="{{.Release.Name}}-grafana", asserts_request_type=~"page|api"}) > 0
+            labels:
+              job: {{.Release.Name}}-server
+              dst_job: {{.Release.Name}}-grafana
+              dst_namespace: {{.Release.Namespace}}
+
           # grafana -> promxyuser
           - record: asserts:relation:calls
             expr: sum by (asserts_env, asserts_site, namespace, job)
-                    (asserts:request:rate5m{job="{{.Release.Name}}-grafana", asserts_request_type="proxy"}) > 0
+                    (asserts:request:rate5m{job="{{.Release.Name}}-grafana", asserts_request_type=~"page|api"}) > 0
             labels:
               dst_job: {{.Release.Name}}-promxyuser
               dst_namespace: {{.Release.Namespace}}
-  {{- else }}
+
+          # if self scraping, then we assume there are no kube-state-metrics
+          # we generate synthetic metrics for discovery from the RED (Request Error Duration) metrics
+          # scraped directly from the Asserts services.
+          {{- if .Values.selfScrape }}
+          - record: asserts:mixin_pod_workload
+            expr: |-
+              group by (asserts_env, namespace, pod, workload)(
+                label_replace(
+                  up{asserts_env="asserts"},
+                  "workload", "$1$2$4",
+                  "pod",
+                  "([a-z0-9-]+)-[0-9]{1,4}|([a-z0-9-]+)-([a-z0-9]{6,})?-[a-z0-9]{5}?|([a-z0-9-]+)-[a-z0-9]{5}?"
+                )
+              )
+            labels:
+              asserts_source: synthetic
+
+          - record: node_uname_info
+            expr: |-
+              label_replace(
+                group by (asserts_env, node)(up{asserts_env="asserts"}),
+                "nodename",
+                "$1",
+                "node",
+                "(.*)"
+              )
+            labels:
+              asserts_source: synthetic
+
+          - record: kube_node_labels
+            expr: |-
+              group by (asserts_env, node)(up{asserts_env="asserts"})
+            labels:
+              asserts_source: synthetic
+
+          - record: kube_pod_info
+            expr: |-
+              group by (asserts_env, namespace, pod, pod_ip, node, created_by_kind, workload)(
+                label_replace(
+                  up{asserts_env="asserts"},
+                  "workload", "$1$2$4",
+                  "pod",
+                  "([a-z0-9-]+)-[0-9]{1,4}|([a-z0-9-]+)-([a-z0-9]{6,})?-[a-z0-9]{5}?|([a-z0-9-]+)-[a-z0-9]{5}?"
+                )
+              )
+            labels:
+              asserts_source: synthetic
+          {{- end }}
+  {{ else }}
   asserts-k8s-calls.yml: |
     groups:
       - name: asserts-k8s-calls.rules
@@ -135,7 +193,7 @@ data:
           # asserts-ui -> authorization
           - record: asserts:relation:calls
             expr: sum by (asserts_env, asserts_site, namespace)
-                    (asserts:request:rate5m{service="{{.Release.Name}}-authorization", asserts_request_type="inbound"}}) > 0
+                    (asserts:request:rate5m{service="{{.Release.Name}}-authorization", asserts_request_type="inbound"}) > 0
             labels:
               workload: {{.Release.Name}}-ui
               dst_workload: {{.Release.Name}}-authorization
@@ -156,7 +214,7 @@ data:
                     (asserts:request:rate5m{service="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context=~".*Search.*"}) > 0
             labels:
               workload: {{.Release.Name}}-server
-              dst_workload: {{.Values.redisearch.fullnameOverride}}-metrics
+              dst_workload: {{.Values.redisearch.fullnameOverride}}-master
               dst_namespace: {{.Release.Namespace}}
 
           # asserts-server -> redisgraph
@@ -165,7 +223,7 @@ data:
               (asserts:request:rate5m{service="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context=~".*Graph.*"}) > 0
             labels:
               workload: {{.Release.Name}}-server
-              dst_workload: {{.Values.redisgraph.fullnameOverride}}-metrics
+              dst_workload: {{.Values.redisgraph.fullnameOverride}}-master
               dst_namespace: {{.Release.Namespace}}
 
           # asserts-server -> tsdb-server
@@ -180,7 +238,7 @@ data:
           # knowledge-sensor -> asserts-server
           - record: asserts:relation:calls
             expr: sum by (asserts_env, asserts_site, namespace)
-                    (asserts:request:rate5m{job="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context="/v4/prometheus/rules"}) > 0
+                    (asserts:request:rate5m{service="{{.Release.Name}}-server", namespace="{{.Release.Namespace}}", asserts_request_context="/v4/prometheus/rules"}) > 0
             labels:
               workload: {{.Release.Name}}-knowledge-sensor
               dst_workload: {{.Release.Name}}-server
@@ -231,10 +289,19 @@ data:
               dst_workload: {{.Release.Name}}-tsdb-server
               dst_namespace: {{.Release.Namespace}}
 
+          # asserts-server -> grafana
+          - record: asserts:relation:calls
+            expr: sum by (asserts_env, asserts_site, namespace, job)
+                    (asserts:request:rate5m{service="{{.Release.Name}}-grafana", asserts_request_type=~"page|api"}) > 0
+            labels:
+              workload: {{.Release.Name}}-server
+              dst_workload: {{.Release.Name}}-grafana
+              dst_namespace: {{.Release.Namespace}}
+
           # grafana -> promxyuser
           - record: asserts:relation:calls
             expr: sum by (asserts_env, asserts_site, namespace, job)
-                    (asserts:request:rate5m{service="{{.Release.Name}}-grafana", asserts_request_type="proxy"}) > 0
+                    (asserts:request:rate5m{service="{{.Release.Name}}-grafana", asserts_request_type=~"page|api"}) > 0
             labels:
               workload: {{.Release.Name}}-grafana
               dst_workload: {{.Release.Name}}-promxyuser

--- a/charts/asserts/templates/config/tsdb-scrape-configmap.yaml
+++ b/charts/asserts/templates/config/tsdb-scrape-configmap.yaml
@@ -122,7 +122,7 @@ data:
       scrape_interval: 30s
       scrape_timeout: 15s
 
-    {{- if or (not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) (not (.Values.serviceMonitor.enabled)) }}
+    {{- if and (not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) (.Values.selfScrape) }}
     ### asserts services ###
     - job_name: {{ .Release.Name }}-server
       kubernetes_sd_configs:
@@ -205,27 +205,17 @@ data:
         target_label: endpoint
         replacement: http
         action: replace
-      # add tenant, asserts_env, & asserts_site
-      # to all remaining values metrics if applicable
+      # add tenant & asserts_env labels
       - separator: ;
         regex: (.*)
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{ .Release.Name }}-authorization
       kubernetes_sd_configs:
@@ -315,20 +305,17 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{ .Release.Name }}-tsdb-server
       kubernetes_sd_configs:
@@ -408,20 +395,17 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{ .Release.Name }}-grafana
       kubernetes_sd_configs:
@@ -501,20 +485,17 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{ .Release.Name }}-alertmanager
       kubernetes_sd_configs:
@@ -594,20 +575,17 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{.Values.postgres.fullnameOverride}}
       kubernetes_sd_configs:
@@ -692,20 +670,17 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{ .Release.Name }}-promxyruler
       kubernetes_sd_configs:
@@ -780,20 +755,17 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{ .Release.Name }}-promxyuser
       kubernetes_sd_configs:
@@ -868,20 +840,17 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{.Values.redisgraph.fullnameOverride}}
       kubernetes_sd_configs:
@@ -966,20 +935,17 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
 
     - job_name: {{.Values.redisearch.fullnameOverride}}
       kubernetes_sd_configs:
@@ -1064,19 +1030,16 @@ data:
         target_label: tenant
         replacement: {{ include "asserts.tenant" . }}
         action: replace
-      {{- if .Values.assertsClusterEnv }}
+      # add tenant & asserts_env labels
+      - separator: ;
+        regex: (.*)
+        target_label: tenant
+        replacement: {{ include "asserts.tenant" . }}
+        action: replace
       - separator: ;
         regex: (.*)
         target_label: asserts_env
-        replacement: {{ .Values.assertsClusterEnv }}
+        replacement: asserts
         action: replace
-      {{- end }}
-      {{- if .Values.assertsClusterSite }}
-      - separator: ;
-        regex: (.*)
-        target_label: asserts_site
-        replacement: {{ .Values.assertsClusterSite }}
-        action: replace
-      {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/asserts/templates/config/tsdb-scrape-configmap.yaml
+++ b/charts/asserts/templates/config/tsdb-scrape-configmap.yaml
@@ -153,17 +153,24 @@ data:
         regex: http
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -246,17 +253,24 @@ data:
         regex: http
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -341,17 +355,24 @@ data:
         regex: http
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -431,17 +452,24 @@ data:
         regex: http
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -521,17 +549,24 @@ data:
         regex: http
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -616,17 +651,24 @@ data:
         regex: http-metrics
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -701,17 +743,24 @@ data:
         regex: {{ .Release.Name }}
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -786,17 +835,24 @@ data:
         regex: {{ .Release.Name }}
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -881,17 +937,24 @@ data:
         regex: http-metrics
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;
@@ -976,17 +1039,24 @@ data:
         regex: http-metrics
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: (.*)
         target_label: node
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        regex: (.*)
+        target_label: created_by_kind
         action: replace
       - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
         separator: ;
         regex: Pod;(.*)
         target_label: pod
         replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_ip]
+        regex: (.*)
+        target_label: pod_ip
         action: replace
       - source_labels: [__meta_kubernetes_namespace]
         separator: ;

--- a/charts/asserts/templates/grafana/service.yaml
+++ b/charts/asserts/templates/grafana/service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   name: {{ include "asserts.grafanaFullname" . }}
   labels: {{- include "asserts.grafanaLabels" . | nindent 4 }}
-  {{- with .Values.grafana.service.annotations }}
-  annotations: {{- toYaml . | nindent 4 -}}
+  {{- if .Values.grafana.service.annotations }}
+  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.grafana.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.grafana.service.clusterIP }}

--- a/charts/asserts/templates/grafana/service.yaml
+++ b/charts/asserts/templates/grafana/service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   name: {{ include "asserts.grafanaFullname" . }}
   labels: {{- include "asserts.grafanaLabels" . | nindent 4 }}
-  {{- if .Values.grafana.service.annotations }}
-  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.grafana.service.annotations "context" $) | nindent 4 }}
+  {{- with .Values.grafana.service.annotations }}
+  annotations: {{ include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.grafana.service.clusterIP }}

--- a/charts/asserts/templates/server/service.yaml
+++ b/charts/asserts/templates/server/service.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- with .Values.server.extraLabels }}
     {{- toYaml . | nindent 4 -}}
     {{- end }}
-  {{- if .Values.server.service.annotations }}
-  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.server.service.annotations "context" $) | nindent 4 }}
+  {{- with .Values.server.service.annotations }}
+  annotations: {{ include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.server.service.type }}

--- a/charts/asserts/templates/server/service.yaml
+++ b/charts/asserts/templates/server/service.yaml
@@ -6,9 +6,8 @@ metadata:
     {{- with .Values.server.extraLabels }}
     {{- toYaml . | nindent 4 -}}
     {{- end }}
-  {{- if .Values.server.annotations }}
-  annotations:
-  {{- toYaml .Values.server.annotations | nindent 4 -}}
+  {{- if .Values.server.service.annotations }}
+  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.server.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.server.service.type }}

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -42,9 +42,6 @@ serviceAccount:
 ## If Asserts is being installed in the same cluster you are running Prometheus-Operator
 ## set this to true and .Values.selfScrape: false
 ##
-## Information on configuring Asserts to monitor Asserts
-## can be seen at: TODO: ADD DOC LINK
-##
 serviceMonitor:
   enabled: false
   # endpoints and appropriate relabelings
@@ -88,9 +85,6 @@ serviceMonitor:
 ##
 ## When this is set to true, the Asserts Tsdb will scrape
 ## all of the Asserts Services independent of your Prometheus.
-##
-## Information on configuring Asserts to monitor Asserts
-## can be seen at: TODO: ADD DOC LINK
 ##
 selfScrape: true
 

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -4,6 +4,7 @@
 ## as well as dependent charts
 ##
 ## Current available global parameters: storageClass, secureCookie
+##
 global:
   storageClass: ""
   # set to true if oauth is configured on Asserts and exclusively using https
@@ -17,7 +18,7 @@ rbac:
   ## Namespaced role and rolebinding
   ## to allow for get/list/watch of
   ## pod, endpoints, and services in the
-  ## installed {{ .Release.Namespace }}
+  ## installed {{.Release.Namespace}}
   create: true
   annotations: {}
   extraLabels: {}
@@ -38,16 +39,17 @@ serviceAccount:
 
 ## ServiceMonitor configuration
 ##
-## If Prometheus-Operator is used (detected by checking "monitoring.coreos.com/v1" api existence)
-## Then this ServiceMonitor will be created and it is expected that Asserts will be scraped by
-## the Prometheus running in the cluster Asserts is installed in.
+## If Asserts is being installed in the same cluster you are running Prometheus-Operator
+## set this to true and .Values.selfScrape: false
+##
+## Information on configuring Asserts to monitor Asserts
+## can be seen at: TODO: ADD DOC LINK
 ##
 serviceMonitor:
-  enabled: true
+  enabled: false
   # endpoints and appropriate relabelings
-  # relabelings used to avoid duplicates
-  # this allows us to avoid errors and keep everything in one
-  # ServiceMonitor
+  # used to avoid duplicates this allows us to
+  # avoid errors and keep everything in one ServiceMonitor
   endpoints:
     - port: http
       path: /api-server/actuator/prometheus
@@ -82,24 +84,15 @@ serviceMonitor:
   # your prometheus-operator serviceMonitorSelector (e.g. release: kube-prometheus-stack)
   extraLabels: {}
 
-## Self scrape configuration
+## Asserts self scrape
 ##
 ## When this is set to true, the Asserts Tsdb will scrape
-## all of the Asserts Services.
+## all of the Asserts Services independent of your Prometheus.
 ##
-## This should only be set to true if
-## the following cases are met:
+## Information on configuring Asserts to monitor Asserts
+## can be seen at: TODO: ADD DOC LINK
 ##
-## 1. You are not running Prometheus-Operator where Asserts is being installed
-## 2. You are not running vanilla Prometheus with annotation based
-##    based service discovery (e.g. prometheus.io/scrape: "true") where Asserts
-##    is being installed.
-## 3. You are installing Asserts in a management or test cluster (kind, k3d) not
-##    running Prometheus/Prometheus-Operator and intend to connect to a remote
-##    Prometheus.
-##
-## If these cases are met, then set to true.
-selfScrape: false
+selfScrape: true
 
 ## Asserts Url
 ##
@@ -111,11 +104,13 @@ selfScrape: false
 ##
 ## If unset, leave the url like this as opposed to empty
 ## as it will work when using port-forwarding.
+##
 assertsUrl: http://localhost:8080
 
 ## Receiver configuration
 ## the notification receiver (e.g. slack, pagerduty, etc..)
 ## wait times/intervals
+##
 receiver:
   group_wait: 1m
   group_interval: 15m

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -36,8 +36,11 @@ serviceAccount:
   annotations: {}
   extraLabels: {}
 
+## ServiceMonitor configuration
+##
 ## If Prometheus-Operator is used (detected by checking "monitoring.coreos.com/v1" api existence)
-## Then they will be created, else the Asserts Tsdb will scrape the services
+## Then this ServiceMonitor will be created and it is expected that Asserts will be scraped by
+## the Prometheus running in the cluster Asserts is installed in.
 ##
 serviceMonitor:
   enabled: true
@@ -76,18 +79,24 @@ serviceMonitor:
   # your prometheus-operator serviceMonitorSelector (e.g. release: kube-prometheus-stack)
   extraLabels: {}
 
-## Asserts cluster env and site
+## Self scrape configuration
 ##
-## IGNORE IF RUNNING Promtheus-Operator!!!
+## When this is set to true, the Asserts Tsdb will scrape
+## all of the Asserts Services.
 ##
-## This is required in order for Asserts to scrape a
-## and monitor itself. This should be set to the env and site
-## of the cluster asserts is being installed in.
-## This means that the env and site of the datasource
-## for this cluster (set in the Asserts UI), should
-## match these values.
-assertsClusterEnv: ""
-assertsClusterSite: ""
+## This should only be set to true if
+## the following cases are met:
+##
+## 1. You are not running Prometheus-Operator where Asserts is being installed
+## 2. You are not running vanilla Prometheus with annotation based
+##    based service discovery (e.g. prometheus.io/scrape: "true") where Asserts
+##    is being installed.
+## 3. You are installing Asserts in a test cluster (kind, k3d) or solo cluster not
+##    running Prometheus/Prometheus-Operator and intend to connect to a remote
+##    Prometheus.
+##
+## If these cases are met, then set to true.
+selfScrape: false
 
 ## Asserts Url
 ##
@@ -174,6 +183,10 @@ server:
   service:
     type: ClusterIP
     port: 8030
+    annotations:
+      prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+      prometheus.io/port: "{{.Values.server.service.port}}"
+      prometheus.io/path: "/api-server/actuator/prometheus"
 
   resources: {}
 
@@ -261,6 +274,10 @@ authorization:
   service:
     type: ClusterIP
     port: 8070
+    annotations:
+      prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+      prometheus.io/port: "{{.Values.authorization.service.port}}"
+      prometheus.io/path: "/authorization/actuator/prometheus"
 
   resources: {}
 
@@ -399,8 +416,10 @@ grafana:
   service:
     type: ClusterIP
     port: 3000
-    annotations: {}
     clusterIP: ""
+    annotations:
+      prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+      prometheus.io/port: "{{.Values.grafana.service.port}}"
 
     ## List of IP addresses at which the Prometheus server service is available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
@@ -579,6 +598,11 @@ tsdb:
     nameOverride: "tsdb"
     fullNameOverride: "tsdb"
 
+    service:
+      annotations:
+        prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+        prometheus.io/port: "8428"
+
     initContainers:
       ## wait for the knowledge-sensor to be ready to
       ## serve up the rules
@@ -718,9 +742,6 @@ redisgraph:
   sentinel:
     enabled: false
 
-  ## TODO: since we are scraping from the tsdb, may want to disable
-  ##       the annotation -> prometheus.io/scrape: true
-  ##       so that there isn't a double scrape from another prom
   metrics:
     enabled: true
 
@@ -734,7 +755,7 @@ redisearch:
   ## ref: https://hub.docker.com/repository/docker/asserts/redismod
   image:
     repository: asserts/redismod
-    tag: 6.26
+    tag: 6.2.7-rg-v2.8.20-rs-v2.14.6
 
   nameOverride: asserts-redisearch
   fullnameOverride: asserts-redisearch
@@ -755,9 +776,6 @@ redisearch:
   sentinel:
     enabled: false
 
-  # TODO: since we are scraping from the tsdb, may want to disable
-  #       the annotation -> prometheus.io/scrape: true
-  #       so that there isn't a double scrape from another prom
   metrics:
     enabled: true
 
@@ -771,6 +789,11 @@ alertmanager:
   serviceAccount:
     create: false
     name: asserts
+
+  service:
+    annotations:
+      prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+      prometheus.io/port: "9093"
 
   persistence:
     enabled: true
@@ -912,8 +935,3 @@ postgres:
 
   metrics:
     enabled: true
-    service:
-      annotations:
-        # set to false since this chart is handling scraping for this service
-        # the Asserts ServiceMonitor is used or the Asserts TSDB is already scraping this endpoint
-        prometheus.io/scrape: "false"

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -68,6 +68,9 @@ serviceMonitor:
           regex: "{{.Release.Name}}-server"
           action: drop
         - sourceLabels: [job]
+          regex: "{{.Release.Name}}-authorization"
+          action: drop
+        - sourceLabels: [job]
           regex: "{{.Release.Name}}-ui"
           action: drop
         - sourceLabels: [job]
@@ -91,7 +94,7 @@ serviceMonitor:
 ## 2. You are not running vanilla Prometheus with annotation based
 ##    based service discovery (e.g. prometheus.io/scrape: "true") where Asserts
 ##    is being installed.
-## 3. You are installing Asserts in a test cluster (kind, k3d) or solo cluster not
+## 3. You are installing Asserts in a management or test cluster (kind, k3d) not
 ##    running Prometheus/Prometheus-Operator and intend to connect to a remote
 ##    Prometheus.
 ##
@@ -136,6 +139,7 @@ pagerduty:
   enabled: false
   # routing_key: <your-events-api-v2-integration-key>
   # url: https://events.pagerduty.com/v2/enqueue
+
 
 ## Asserts server configuration
 ##
@@ -184,7 +188,7 @@ server:
     type: ClusterIP
     port: 8030
     annotations:
-      prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+      prometheus.io/scrape: "true"
       prometheus.io/port: "{{.Values.server.service.port}}"
       prometheus.io/path: "/api-server/actuator/prometheus"
 
@@ -275,7 +279,7 @@ authorization:
     type: ClusterIP
     port: 8070
     annotations:
-      prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+      prometheus.io/scrape: "true"
       prometheus.io/port: "{{.Values.authorization.service.port}}"
       prometheus.io/path: "/authorization/actuator/prometheus"
 
@@ -418,7 +422,7 @@ grafana:
     port: 3000
     clusterIP: ""
     annotations:
-      prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+      prometheus.io/scrape: "true"
       prometheus.io/port: "{{.Values.grafana.service.port}}"
 
     ## List of IP addresses at which the Prometheus server service is available
@@ -600,7 +604,7 @@ tsdb:
 
     service:
       annotations:
-        prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+        prometheus.io/scrape: "true"
         prometheus.io/port: "8428"
 
     initContainers:
@@ -792,7 +796,7 @@ alertmanager:
 
   service:
     annotations:
-      prometheus.io/scrape: "{{include \"promScrapeAnnotation\" .}}"
+      prometheus.io/scrape: "true"
       prometheus.io/port: "9093"
 
   persistence:
@@ -817,6 +821,11 @@ promxyruler:
   serviceAccount:
     create: false
     name: asserts
+
+  service:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8082"
 
   existingConfigMap: asserts-promxyruler
 
@@ -875,6 +884,11 @@ promxyuser:
   serviceAccount:
     create: false
     name: asserts
+
+  service:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8082"
 
   existingConfigMap: asserts-promxyuser
 


### PR DESCRIPTION
Purpose of this PR is to be explicit in the methods of installation AND provide a better experience without requiring too much configuration. The only thing missing here is a link or explanation of how to change the relabeling for a "mega job" sitiuation. This would be the 2nd option in the updated installation docs. Want to get feedback and have some folks try these out before adding that into the mix.

Most of the rules in k8s-calls-rules are a copy of the original but then using `service` instead of `job` for mega jobs. The synthetic metrics are added for a selfScrape situation where no kube-state-metrics are present.

I've thoroughly tested all 3 methods with

* Prometheus-Operator
* Prometheus with KSM and NodeExporter (mega job, no operator)
* A Bare cluster only installing Asserts (self scrape option)

What we should do is get everyone on the team to try an option or 2, finalize this, and put it out. Just a first step in improving are default experience while being more explicit.