### PR TITLE
Comment on scrapeInterval

### DIFF
--- a/charts/asserts/Chart.yaml
+++ b/charts/asserts/Chart.yaml
@@ -4,7 +4,7 @@ description: Asserts Helm Chart to configure entire asserts stack
 icon: https://www.asserts.ai/favicon.png
 type: application
 
-version: 1.21.0
+version: 1.22.0
 
 dependencies:
   ### asserts charts ###

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -484,10 +484,8 @@ grafana:
     password: ""
     existingSecret: ""
 
-  # lowest interval/step value that should be used for the Prometheus data source
-  # should optimally be at least 2x your scrapeInterval in Prometheus
-  # set in .Values.grafana.datasources[0].jsonData.timeInterval
-  timeInterval: 60s
+  # set to at least 2x the scrapeInterval of your Prometheus
+  scrapeInterval: 60s
 
   # ref: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file
   datasources:
@@ -499,7 +497,7 @@ grafana:
         access: proxy
         type: prometheus
         jsonData:
-          timeInterval: "{{.Values.grafana.timeInterval}}"
+          timeInterval: "{{.Values.grafana.scrapeInterval}}"
 
   dataPath: /var/lib/grafana/data
 

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -484,7 +484,7 @@ grafana:
     password: ""
     existingSecret: ""
 
-  # set to at least 2x the scrapeInterval of your Prometheus
+  # set to the scrapeInterval of your Prometheus
   scrapeInterval: 60s
 
   # ref: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -484,9 +484,10 @@ grafana:
     password: ""
     existingSecret: ""
 
-  # scrape interval for grafana datasource
+  # lowest interval/step value that should be used for the Prometheus data source
+  # should optimally be at least 2x your scrapeInterval in Prometheus
   # set in .Values.grafana.datasources[0].jsonData.timeInterval
-  scrapeInterval: 30s
+  timeInterval: 60s
 
   # ref: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file
   datasources:
@@ -498,7 +499,7 @@ grafana:
         access: proxy
         type: prometheus
         jsonData:
-          timeInterval: "{{.Values.grafana.scrapeInterval}}"
+          timeInterval: "{{.Values.grafana.timeInterval}}"
 
   dataPath: /var/lib/grafana/data
 

--- a/charts/asserts/values.yaml
+++ b/charts/asserts/values.yaml
@@ -485,7 +485,8 @@ grafana:
     existingSecret: ""
 
   # set to the scrapeInterval of your Prometheus
-  scrapeInterval: 60s
+  # but never smaller than 30s (default)
+  scrapeInterval: 30s
 
   # ref: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file
   datasources:


### PR DESCRIPTION
The only group using the old `scrapeInterval` value is levo and we are going to meet with them to drop their install and redo. Also, they have it set to 60s, so it wouldn't matter anyway.