### PR TITLE
Use deterministic container name

### DIFF
--- a/charts/ebpf-probe/Chart.yaml
+++ b/charts/ebpf-probe/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 apiVersion: v2
 appVersion: 0.3.0
 name: ebpf-probe

--- a/charts/ebpf-probe/templates/daemonset.yaml
+++ b/charts/ebpf-probe/templates/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: ebpf-probe
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
This is needed to use an alias from the Asserts chart. We shouldn't be changing the container name anyway.