### PR TITLE
Upgrade otel-collector and add new values

### DIFF
--- a/charts/otel-collector/Chart.yaml
+++ b/charts/otel-collector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: otel-collector
 description: Asserts Opentelemetry Collector
 type: application
-version: 0.1.0
-appVersion: v0.0.92-all-exporters
+version: 0.2.0
+appVersion: v0.0.93-all-exporters
 
 maintainers:
   - name: Asserts

--- a/charts/otel-collector/templates/_helpers.tpl
+++ b/charts/otel-collector/templates/_helpers.tpl
@@ -62,6 +62,40 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports ingressClassName.
+*/}}
+{{- define "ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "kubeVersion" .))) -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "kubeVersion" .))) -}}
+{{- end -}}
+
+{{/*
 Renders a value that contains template.
 Usage:
 {{ include "render-values" ( dict "value" .Values.path.to.the.Value "context" $) }}

--- a/charts/otel-collector/templates/_helpers.tpl
+++ b/charts/otel-collector/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "render-values" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "render-values" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/otel-collector/templates/_helpers.tpl
+++ b/charts/otel-collector/templates/_helpers.tpl
@@ -62,6 +62,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Get KubeVersion removing pre-release information.
+*/}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+" .Capabilities.KubeVersion.Version) -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "ingress.apiVersion" -}}

--- a/charts/otel-collector/templates/deployment.yaml
+++ b/charts/otel-collector/templates/deployment.yaml
@@ -31,6 +31,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command: {{- include "render-values" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "render-values" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
           env:
             - name: TRACE_STORE
               value: {{ .Values.traceStore }}

--- a/charts/otel-collector/templates/ingress.yaml
+++ b/charts/otel-collector/templates/ingress.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+{{- $serviceName := include "otel-collector.fullname" . }}
+{{- $servicePort := .Values.ports.oltp.servicePort -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
+{{- $extraPaths := .Values.ingress.extraPaths -}}
+apiVersion: {{ template "ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
+  labels:
+    {{- include "otel-collector.labels" . | nindent 4 }}
+{{- range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key }}: {{ $value }}
+{{- end }}
+  name: {{ template "otel-collector.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    {{- $url := splitList "/" . }}
+    - host: {{ first $url }}
+      http:
+        paths:
+{{ if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
+          - path: {{ $ingressPath }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
+            backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+              {{- end }}
+  {{- end -}}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/otel-collector/templates/ingress.yaml
+++ b/charts/otel-collector/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 {{- $serviceName := include "otel-collector.fullname" . }}
-{{- $servicePort := .Values.ports.oltp.servicePort -}}
+{{- $servicePort := .Values.ports.otlp.servicePort -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}

--- a/charts/otel-collector/templates/service.yaml
+++ b/charts/otel-collector/templates/service.yaml
@@ -4,9 +4,8 @@ metadata:
   name: {{ include "otel-collector.fullname" . }}
   labels:
     {{- include "otel-collector.labels" . | nindent 4 }}
-  annotations:
-  {{- with .Values.podAnnotations }}
-  {{- toYaml . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 -}}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/otel-collector/templates/servicemonitor.yaml
+++ b/charts/otel-collector/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (.Values.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name:  {{ include "otel-collector.fullname" . }}
+  labels: {{- include "otel-collector.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 -}}
+    {{- end }}
+spec:
+  endpoints:
+  {{- range $endpoint := .Values.serviceMonitor.endpoints }}
+    - port: {{ $endpoint.port }}
+  {{- with $endpoint.path }}
+      path: {{ . }}
+  {{- end }}
+  {{- with $endpoint.honorLabels }}
+      honorLabels: {{ . }}
+  {{- end }}
+  {{- with $endpoint.interval }}
+      interval: {{ . }}
+  {{- end }}
+  {{- with $endpoint.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+  {{- end }}
+  {{- with $endpoint.relabelings }}
+      relabelings: {{ include "render-values" ( dict "value" $endpoint.relabelings "context" $) | nindent 8 }}
+  {{- end }}
+  {{- with $endpoint.metricRelabelings }}
+      metricRelabelings: {{ include "render-values" ( dict "value" $endpoint.metricRelabelings "context" $) | nindent 8 }}
+  {{- end }}
+  {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ include "otel-collector.fullname" . }}
+{{- end }}

--- a/charts/otel-collector/values.yaml
+++ b/charts/otel-collector/values.yaml
@@ -42,6 +42,8 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext: {}
+  # enabled: false
+  # allowPrivilegeEscalation: false
   # capabilities:
   #   drop:
   #   - ALL
@@ -55,6 +57,27 @@ service:
   # type: LoadBalancer
   # loadBalancerIP: 1.2.3.4
   # loadBalancerSourceRanges: []
+
+## ServiceMonitor configuration
+##
+serviceMonitor:
+  enabled: false
+  endpoints:
+    - port: otel-metrics
+      path: /metrics
+      honorLabels: true
+    - port: prom-metrics
+      path: /metrics
+      honorLabels: true
+    - port: http-metrics
+      path: /metrics
+      honorLabels: true
+  # Use if you need to add a label that matches
+  # your prometheus-operator serviceMonitorSelector (e.g. release: kube-prometheus-stack)
+  extraLabels: {}
+
+command: []
+args: []
 
 resources: {}
   # limits:

--- a/charts/otel-collector/values.yaml
+++ b/charts/otel-collector/values.yaml
@@ -58,6 +58,37 @@ service:
   # loadBalancerIP: 1.2.3.4
   # loadBalancerSourceRanges: []
 
+ingress:
+  enabled: false
+
+  ## For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+
+  annotations: {}
+
+  extraLabels: {}
+
+  hosts: []
+  #   - asserts-otel-collector.domain.com
+
+  path: /
+
+  ## pathType is only for k8s >= 1.18
+  pathType: Prefix
+
+  ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  extraPaths: []
+  # - path: /
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+
+  tls: []
+  #   - secretName: asserts-otel-collector-tls
+  #     hosts:
+  #       - asserts-otel-collector.domain.com
+
 ## ServiceMonitor configuration
 ##
 serviceMonitor:


### PR DESCRIPTION
TODO:

* Wait for v0.93.0-all-exporter image to be built/merged at https://github.com/asserts/asserts-otel-processor/pull/67
* Check securityContext of new values
* Add extraPaths for ingress and test
* Use args and values (needing but no limited to):

```
assertsApiEndpoint: "http://asserts-server.asserts.svc.cluster.local:8030/api-server"
assertsUser: "bootstrap"
assertsPassword: ""
assertsEnv: "<ENV>"
assertsSite: "<SITE>"

args:
  - java
  - -javaagent:opentelemetry-javaagent.jar
  - -Dotel.metrics.exporter=none
  - -Dotel.exporter.otlp.traces.endpoint=$OTEL_COLLECTOR
  - -jar enterprise-server.jar
  - --spring.config.location=conf/application.yml

serviceMonitor:
  enabled: true
  extraLabels:
    release: kube-prometheus-stack
```

If new release isn't done before deployment of chart. The `args` values are due to the asserts-server image having the incorrect command line.